### PR TITLE
Fix warnings and remove "the libxc bool"

### DIFF
--- a/python/mrchem/helpers.py
+++ b/python/mrchem/helpers.py
@@ -123,8 +123,8 @@ def write_scf_fock(user_dict, wf_dict, origin):
         }
 
     # Exchange-Correlation library
-    if wf_dict["method_type"] in ["dft"]:
-        fock_dict["xc_library"] = user_dict["DFT"]["xc_library"],
+    if wf_dict["method_type"] in ["dft"] and "xc_library" not in fock_dict:
+        fock_dict["xc_library"] = user_dict["DFT"]["xc_library"]
 
     # External electric field
     if len(user_dict["ExternalFields"]["electric_field"]) > 0:
@@ -489,10 +489,8 @@ def write_rsp_fock(user_dict, wf_dict):
         }
 
     # Exchange-Correlation library
-    if wf_dict["method_type"] in ["dft"]:
-        fock_dict["xc_library"] = {
-            "xc_library": user_dict["DFT"]["xc_library"],
-        }
+    if wf_dict["method_type"] in ["dft"] and "xc_library" not in fock_dict:
+        fock_dict["xc_library"] = user_dict["DFT"]["xc_library"]
 
     # Reaction
     if user_dict["WaveFunction"]["environment"].lower() != "none":

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -347,7 +347,7 @@ json driver::scf::run(const json &json_scf, Molecule &mol) {
         solver.setRotation(rotation);
         solver.setLocalize(localize);
         solver.setMethodName(method);
-        solver.setLibxc((xc_lib == "libxc") ? true : false);
+        solver.setXCLibName(xc_lib);
         solver.setRelativityName(relativity);
         solver.setEnvironmentName(environment);
         solver.setExternalFieldName(external_field);
@@ -569,7 +569,7 @@ bool driver::scf::guess_energy(const json &json_guess, Molecule &mol, FockBuilde
     mrcpp::print::separator(0, '~');
     print_utils::text(0, "Calculation    ", "Compute initial energy");
     print_utils::text(0, "Method         ", method);
-    print_utils::text(0, "XC Library     ", (xc_lib == "libxc") ? "LibXC" : "XCFun");
+    print_utils::text(0, "XC Library     ", xc_lib);
     print_utils::text(0, "Relativity     ", relativity);
     print_utils::text(0, "Environment    ", environment);
     print_utils::text(0, "External fields", external_field);

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1489,9 +1489,7 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockBuild
             xc_lib = "xcfun";
         }
 
-        mrdft::Factory xc_factory(*MRA);
-        xc_factory.setSpin(xc_spin);
-        xc_factory.setLibxc((xc_lib == "libxc") ? true : false);
+        mrdft::Factory xc_factory(*MRA, xc_spin, xc_lib);
         xc_factory.setOrder(xc_order);
         xc_factory.setDensityCutoff(xc_cutoff);
         for (const auto &f : xc_funcs) {

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -280,8 +280,10 @@ json driver::scf::run(const json &json_scf, Molecule &mol) {
     std::string xc_lib;
 
     if (json_scf["fock_operator"].contains("xc_library")) {
-        xc_lib = json_scf["fock_operator"]["xc_library"][0].get<std::string>();
-    } else {xc_lib = "xcfun";}
+        xc_lib = json_scf["fock_operator"]["xc_library"].get<std::string>();
+    } else {
+        xc_lib = "xcfun";
+    }
 
     ///////////////////////////////////////////////////////////
     ////////////////   Building Fock Operator   ///////////////
@@ -1480,11 +1482,7 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockBuild
         // TODO: Look over and input parser so this is not necessary
         std::string xc_lib;
         if (json_fock.contains("xc_library")) {
-            if(json_fock["xc_library"].is_array()){
-                xc_lib = json_fock["xc_library"][0].get<std::string>();
-            }else{
-                xc_lib = json_fock["xc_library"]["xc_library"].get<std::string>();
-            }
+            xc_lib = json_fock["xc_library"].get<std::string>();
         } else {
             xc_lib = "xcfun";
         }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -410,6 +410,7 @@ bool driver::scf::guess_orbitals(const json &json_guess, const json &json_occ, M
     auto cube_p = json_guess["file_CUBE_p"];
     auto cube_a = json_guess["file_CUBE_a"];
     auto cube_b = json_guess["file_CUBE_b"];
+    auto xclib = json_guess["xc_library"];
 
     int mult = mol.getMultiplicity();
     if (restricted && mult != 1) {
@@ -523,15 +524,14 @@ bool driver::scf::guess_orbitals(const json &json_guess, const json &json_occ, M
     } else if (type == "core") {
         success = initial_guess::core::setup(Phi, prec, nucs, zeta);
     } else if (type == "sad") {
-        success = initial_guess::sad::setup(Phi, prec, screen, nucs, zeta);
+        success = initial_guess::sad::setup(Phi, prec, screen, nucs, xclib, zeta);
     } else if (type == "sad_gto") {
-        success = initial_guess::sad::setup(Phi, prec, screen, nucs);
+        success = initial_guess::sad::setup(Phi, prec, screen, nucs, xclib);
     } else if (type == "gto") {
         success = initial_guess::gto::setup(Phi, prec, screen, gto_bas, gto_p, gto_a, gto_b);
     } else if (type == "cube") {
         success = initial_guess::cube::setup(Phi, prec, cube_p, cube_a, cube_b);
     } else if (type == "nao") {
-
         int nmix = 1;
         std::string key = "initial_mixing_steps";
         if (json_guess.contains(key)) nmix = json_guess[key];
@@ -542,8 +542,7 @@ bool driver::scf::guess_orbitals(const json &json_guess, const json &json_occ, M
         std::string nao_directory = "";
         if (json_guess.contains(key)) nao_directory = json_guess[key];
 
-
-        success = initial_guess::nao::setup(Phi, prec, nucs, nmix, alpha_mix, nao_directory);
+        success = initial_guess::nao::setup(Phi, prec, nucs, nmix, alpha_mix, xclib, nao_directory);
     } else {
         MSG_ERROR("Invalid initial guess");
         success = false;

--- a/src/initial_guess/nao.cpp
+++ b/src/initial_guess/nao.cpp
@@ -66,7 +66,7 @@ using mrcpp::Timer;
 
 namespace mrchem {
 
-bool initial_guess::nao::setup(OrbitalVector &Phi, double prec, const Nuclei &nucs, int n_mix, double alpha_mix, std::string nao_directory) {
+bool initial_guess::nao::setup(OrbitalVector &Phi, double prec, const Nuclei &nucs, int n_mix, double alpha_mix, const std::string &xclib, std::string nao_directory) {
     if (Phi.size() == 0) return false;
 
     auto restricted = (orbital::size_singly(Phi)) ? false : true;
@@ -93,7 +93,7 @@ bool initial_guess::nao::setup(OrbitalVector &Phi, double prec, const Nuclei &nu
     auto P_p = std::make_shared<mrcpp::PoissonOperator>(*MRA, prec);
     auto D_p = std::make_shared<mrcpp::ABGVOperator<3>>(*MRA, 0.0, 0.0);
 
-    mrdft::Factory xc_factory(*MRA, false, "xcfun");
+    mrdft::Factory xc_factory(*MRA, false, xclib);
     xc_factory.setFunctional("SLATERX", 1.0);
     xc_factory.setFunctional("VWN5C", 1.0);
     auto mrdft_p = xc_factory.build();

--- a/src/initial_guess/nao.cpp
+++ b/src/initial_guess/nao.cpp
@@ -93,8 +93,7 @@ bool initial_guess::nao::setup(OrbitalVector &Phi, double prec, const Nuclei &nu
     auto P_p = std::make_shared<mrcpp::PoissonOperator>(*MRA, prec);
     auto D_p = std::make_shared<mrcpp::ABGVOperator<3>>(*MRA, 0.0, 0.0);
 
-    mrdft::Factory xc_factory(*MRA);
-    xc_factory.setSpin(false);
+    mrdft::Factory xc_factory(*MRA, false, "xcfun");
     xc_factory.setFunctional("SLATERX", 1.0);
     xc_factory.setFunctional("VWN5C", 1.0);
     auto mrdft_p = xc_factory.build();

--- a/src/initial_guess/nao.h
+++ b/src/initial_guess/nao.h
@@ -43,7 +43,7 @@ class Nuclei;
 namespace initial_guess {
 namespace nao {
 
-bool setup(OrbitalVector &Phi, double prec, const Nuclei &nucs, int n_mix, double alpha_mix, std::string nao_directory = "");
+bool setup(OrbitalVector &Phi, double prec, const Nuclei &nucs, int n_mix, double alpha_mix, const std::string &xclib, std::string nao_directory = "");
 void project_atomic_densities(double prec, Density &rho_tot, const Nuclei &nucs);
 void project_atomic_orbitals(double prec, OrbitalVector &Phi, const Nuclei &nucs, std::string nao_directory = "");
 

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -61,7 +61,7 @@ void project_atomic_densities(double prec, Density &rho_tot, const Nuclei &nucs,
 } // namespace sad
 } // namespace initial_guess
 
-bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, const Nuclei &nucs, int zeta) {
+bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, const Nuclei &nucs, const std::string &xclib, int zeta) {
     if (Phi.size() == 0) return false;
 
     auto restricted = (orbital::size_doubly(Phi)) ? true : false;
@@ -72,7 +72,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     print_utils::text(0, "Screening   ", print_utils::dbl_to_str(screen, 5, true) + " StdDev");
     print_utils::text(0, "Restricted  ", (restricted) ? "True" : "False");
     print_utils::text(0, "Functional  ", "LDA (SVWN5)");
-    print_utils::text(0, "XC Library  ", "XCFun");
+    print_utils::text(0, "XC Library  ", xclib);
     print_utils::text(0, "AO basis    ", "Hydrogenic orbitals");
     print_utils::text(0, "Zeta quality", std::to_string(zeta));
     mrcpp::print::separator(0, '~', 2);
@@ -82,7 +82,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     auto P_p = std::make_shared<mrcpp::PoissonOperator>(*MRA, prec);
     auto D_p = std::make_shared<mrcpp::ABGVOperator<3>>(*MRA, 0.0, 0.0);
 
-    mrdft::Factory xc_factory(*MRA, false, "xcfun");
+    mrdft::Factory xc_factory(*MRA, false, xclib);
     xc_factory.setFunctional("SLATERX", 1.0);
     xc_factory.setFunctional("VWN5C", 1.0);
     auto mrdft_p = xc_factory.build();
@@ -140,7 +140,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     return true;
 }
 
-bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, const Nuclei &nucs) {
+bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, const Nuclei &nucs, const std::string &xclib) {
     if (Phi.size() == 0) return false;
 
     auto restricted = (orbital::size_doubly(Phi)) ? true : false;
@@ -151,7 +151,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     print_utils::text(0, "Screening   ", print_utils::dbl_to_str(screen, 5, true) + " StdDev");
     print_utils::text(0, "Restricted  ", (restricted) ? "True" : "False");
     print_utils::text(0, "Functional  ", "LDA (SVWN5)");
-    print_utils::text(0, "XC Library  ", "XCFun");
+    print_utils::text(0, "XC Library  ", xclib);
     print_utils::text(0, "AO basis    ", "3-21G");
     mrcpp::print::separator(0, '~', 2);
 
@@ -160,7 +160,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     auto P_p = std::make_shared<mrcpp::PoissonOperator>(*MRA, prec);
     auto D_p = std::make_shared<mrcpp::ABGVOperator<3>>(*MRA, 0.0, 0.0);
 
-    mrdft::Factory xc_factory(*MRA, false, "xcfun");
+    mrdft::Factory xc_factory(*MRA, false, xclib);
     xc_factory.setFunctional("SLATERX", 1.0);
     xc_factory.setFunctional("VWN5C", 1.0);
     auto mrdft_p = xc_factory.build();

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -72,7 +72,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     print_utils::text(0, "Screening   ", print_utils::dbl_to_str(screen, 5, true) + " StdDev");
     print_utils::text(0, "Restricted  ", (restricted) ? "True" : "False");
     print_utils::text(0, "Functional  ", "LDA (SVWN5)");
-    print_utils::text(0, "XC Library  ", (mrdft::XClib::libxc) ? "LibXC" : "XCFun");
+    print_utils::text(0, "XC Library  ", "XCFun");
     print_utils::text(0, "AO basis    ", "Hydrogenic orbitals");
     print_utils::text(0, "Zeta quality", std::to_string(zeta));
     mrcpp::print::separator(0, '~', 2);
@@ -82,8 +82,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     auto P_p = std::make_shared<mrcpp::PoissonOperator>(*MRA, prec);
     auto D_p = std::make_shared<mrcpp::ABGVOperator<3>>(*MRA, 0.0, 0.0);
 
-    mrdft::Factory xc_factory(*MRA);
-    xc_factory.setSpin(false);
+    mrdft::Factory xc_factory(*MRA, false, "xcfun");
     xc_factory.setFunctional("SLATERX", 1.0);
     xc_factory.setFunctional("VWN5C", 1.0);
     auto mrdft_p = xc_factory.build();
@@ -152,7 +151,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     print_utils::text(0, "Screening   ", print_utils::dbl_to_str(screen, 5, true) + " StdDev");
     print_utils::text(0, "Restricted  ", (restricted) ? "True" : "False");
     print_utils::text(0, "Functional  ", "LDA (SVWN5)");
-    print_utils::text(0, "XC Library  ", (mrdft::XClib::libxc) ? "LibXC" : "XCFun");
+    print_utils::text(0, "XC Library  ", "XCFun");
     print_utils::text(0, "AO basis    ", "3-21G");
     mrcpp::print::separator(0, '~', 2);
 
@@ -161,8 +160,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     auto P_p = std::make_shared<mrcpp::PoissonOperator>(*MRA, prec);
     auto D_p = std::make_shared<mrcpp::ABGVOperator<3>>(*MRA, 0.0, 0.0);
 
-    mrdft::Factory xc_factory(*MRA);
-    xc_factory.setSpin(false);
+    mrdft::Factory xc_factory(*MRA, false, "xcfun");
     xc_factory.setFunctional("SLATERX", 1.0);
     xc_factory.setFunctional("VWN5C", 1.0);
     auto mrdft_p = xc_factory.build();

--- a/src/initial_guess/sad.h
+++ b/src/initial_guess/sad.h
@@ -41,8 +41,8 @@ class Nuclei;
 namespace initial_guess {
 namespace sad {
 
-bool setup(OrbitalVector &Phi, double prec, double screen, const Nuclei &nucs, int zeta);
-bool setup(OrbitalVector &Phi, double prec, double screen, const Nuclei &nucs);
+bool setup(OrbitalVector &Phi, double prec, double screen, const Nuclei &nucs, const std::string &xclib, int zeta);
+bool setup(OrbitalVector &Phi, double prec, double screen, const Nuclei &nucs, const std::string &xclib);
 
 } // namespace sad
 } // namespace initial_guess

--- a/src/mrdft/Factory.cpp
+++ b/src/mrdft/Factory.cpp
@@ -39,41 +39,13 @@
 
 namespace mrdft {
 
-bool XClib::libxc = false;
-
-Factory::Factory(const mrcpp::MultiResolutionAnalysis<3> &MRA)
-        : mra(MRA) {
-    if (XClib::libxc) {
-        xclib = std::make_unique<Libxc>(spin);
-    } else {
+Factory::Factory(const mrcpp::MultiResolutionAnalysis<3> &MRA, bool spin, const std::string &xclibname)
+        : spin(spin), xclibname(xclibname), mra(MRA) {
+    if (xclibname == "xcfun") {
         xclib = std::make_unique<XCFun>(spin);
-    }
-}
-void Factory::rebuildXClib() {
-    if (!xclib) { return; }
-
-    const auto functional_specs = xclib->getFunctionalSpecs();
-    if (XClib::libxc) {
+    } else if (xclibname == "libxc") {
         xclib = std::make_unique<Libxc>(spin);
-    } else {
-        xclib = std::make_unique<XCFun>(spin);
     }
-
-    for (const auto &[name, coef] : functional_specs) { xclib->setFunctional(name, coef, cutoff); }
-}
-
-void Factory::setLibxc(bool libxc_) {
-    if (XClib::libxc == libxc_) { return; }
-
-    XClib::libxc = libxc_;
-    rebuildXClib();
-}
-
-void Factory::setSpin(bool s) {
-    if (spin == s) { return; }
-
-    spin = s;
-    rebuildXClib();
 }
 
 void Factory::setFunctional(const std::string &name, double c) {

--- a/src/mrdft/Factory.h
+++ b/src/mrdft/Factory.h
@@ -43,19 +43,17 @@ public:
      * @param[in] MRA The Multi-Resolution Analysis object providing the grid
      * and basis functions for the calculation
      */
-    Factory(const mrcpp::MultiResolutionAnalysis<3> &MRA);
+    Factory(const mrcpp::MultiResolutionAnalysis<3> &MRA, bool spin, const std::string &libname);
 
     ~Factory() = default; ///< @brief Default destructor
 
     /*
      * Setters
      */
-    void setSpin(bool s);                                    ///< Set spin polarization (true for unrestricted/spin-polarized) */
     void setOrder(int k) { order = k; }                      ///< Set the polynomial order for the MRA basis
     void setUseGamma(bool g) { gamma = g; }                  ///< Toggle between gamma-type and explicit derivatives
     void setLogGradient(bool lg) { log_grad = lg; }          ///< Toggle the use of logarithmic gradients
     void setDensityCutoff(double c) { cutoff = c; }          ///< Set the threshold for neglecting low-density regions
-    void setLibxc(bool libxc_);                              ///< Toggle between Libxc (true) and XCFun (false) backends
     void setDerivative(const std::string &n) { diff_s = n; } ///< Set derivative operator type (e.g., "bspline", "abgv_00")
 
     /**
@@ -90,14 +88,13 @@ public:
     std::unique_ptr<MRDFT> build();
 
 private:
-    void rebuildXClib();           ///< @brief Rebuilds the XClib backend
-
     int order{1};                  ///< Polynomial order of the Multi-Resolution Analysis (MRA) basis
     bool spin{false};              ///< If true, perform unrestricted calculations
     bool gamma{false};             ///< If true, use gamma-type derivatives (gradient squared) instead of explicit components
     bool log_grad{false};          ///< Toggle for using logarithmic gradient transformations
     double cutoff{-1.0};           ///< Density threshold; values below this are sat to 0
     std::string diff_s{"abgv_00"}; ///< String identifier for the derivative operator type (e.g., "bspline", "abgv_55")
+    std::string xclibname;
 
     const mrcpp::MultiResolutionAnalysis<3> mra;          ///< @brief Reference to the 3D Multi-Resolution Analysis grid structure
     std::unique_ptr<mrcpp::DerivativeOperator<3>> diff_p; ///< @brief Pointer to the numerical derivative operator used for GGA gradients

--- a/src/mrdft/GGA.h
+++ b/src/mrdft/GGA.h
@@ -74,7 +74,7 @@ private:
      * Ownership of densities is outside MRDFT -> clear
      * Ownership of gradients is inside MRDFT -> free
      */
-    void clear() {
+    void clear() override {
         mrcpp::clear(this->rho, false);
         mrcpp::clear(this->grad, true);
     }

--- a/src/mrdft/LDA.h
+++ b/src/mrdft/LDA.h
@@ -69,7 +69,7 @@ private:
      *
      * Ownership of densities is outside MRDFT -> clear
      */
-    void clear() { mrcpp::clear(this->rho, false); }
+    void clear() override { mrcpp::clear(this->rho, false); }
 };
 
 } // namespace mrdft

--- a/src/mrdft/SpinGGA.h
+++ b/src/mrdft/SpinGGA.h
@@ -76,7 +76,7 @@ private:
      * Ownership of densities (alpha, beta) is outside MRDFT -> clear
      * Ownership of gradients (alpha, beta) is inside MRDFT -> free
      */
-    void clear() {
+    void clear() override {
         mrcpp::clear(this->rho_a, false);
         mrcpp::clear(this->rho_b, false);
         mrcpp::clear(this->grad_a, true);

--- a/src/mrdft/SpinLDA.h
+++ b/src/mrdft/SpinLDA.h
@@ -70,7 +70,7 @@ private:
      *
      * Ownership of densities (alpha, beta) is outside MRDFT -> clear
      */
-    void clear() {
+    void clear() override {
         mrcpp::clear(this->rho_a, false);
         mrcpp::clear(this->rho_b, false);
     }

--- a/src/mrdft/xclib.h
+++ b/src/mrdft/xclib.h
@@ -47,7 +47,6 @@ public:
 
     virtual ~XClib() = default;
 
-    static bool libxc;                                            ///< @brief Flag indicating if Libxc is active (True if "DFT {xc_library = libxc}" in input file)
     bool spin;                                                    ///< @brief True if density is spin-polarized
     std::vector<std::pair<std::string, double>> functional_specs; ///< @brief Configured functionals and scaling coefficients
     virtual double getAmountExx() const = 0;                      ///< @brief Get total fraction of exact exchange

--- a/src/mrdft/xclib_Libxc.cpp
+++ b/src/mrdft/xclib_Libxc.cpp
@@ -153,13 +153,13 @@ void Libxc::callLibEval(const Eigen::MatrixXd &inp, Eigen::MatrixXd &out, int nP
                     Eigen::MatrixXd rho = Eigen::MatrixXd::Zero(2, nPts);
                     exc = Eigen::MatrixXd::Zero(1, nPts);
                     vxc = Eigen::MatrixXd::Zero(2, nPts);
-                    for (size_t j = 0; j < nPts; j++) {
+                    for (int j = 0; j < nPts; j++) {
                         // alpha_1, beta_1, alpha_2, beta_2, ..
                         rho(0, j) = inp(0, j);
                         rho(1, j) = inp(1, j);
                     }
                     xc_lda_exc_vxc(libxc_objects[i], nPts, rho.data(), exc.data(), vxc.data());
-                    for (size_t j = 0; j < nPts; ++j) {
+                    for (int j = 0; j < nPts; ++j) {
                         //    xcfun calculates actual energy density while libxc calculates
                         //    energy density per electron density
 
@@ -172,7 +172,7 @@ void Libxc::callLibEval(const Eigen::MatrixXd &inp, Eigen::MatrixXd &out, int nP
                     exc = Eigen::MatrixXd::Zero(1, nPts);
                     vxc = Eigen::MatrixXd::Zero(1, nPts);
                     xc_lda_exc_vxc(libxc_objects[i], nPts, inp.data(), exc.data(), vxc.data());
-                    for (size_t j = 0; j < nPts; ++j) {
+                    for (int j = 0; j < nPts; ++j) {
                         //    xcfun calculates actual energy density while libxc calculates
                         //    energy density per electron density
                         out(0, j) += exc(0, j) * libxc_coefs[i] * inp(0, j);
@@ -188,12 +188,12 @@ void Libxc::callLibEval(const Eigen::MatrixXd &inp, Eigen::MatrixXd &out, int nP
                     vxc = Eigen::MatrixXd::Zero(2, nPts);
                     sxc = Eigen::MatrixXd::Zero(3, nPts);
                     sigma = Eigen::MatrixXd::Zero(3, nPts);
-                    for (size_t j = 0; j < nPts; j++) {
+                    for (int j = 0; j < nPts; j++) {
                         // alpha_1, beta_1, alpha_2, beta_2, ..
                         rho(0, j) = inp(0, j);
                         rho(1, j) = inp(1, j);
                     }
-                    for (size_t j = 0; j < nPts; j++) {
+                    for (int j = 0; j < nPts; j++) {
                         // clang-format off
                         // Libxc takes in reduced gradients: up-up, up-down, down-down
                         sigma(0, j) = inp(2, j) * inp(2, j) + inp(3, j) * inp(3, j) + inp(4, j) * inp(4, j);
@@ -202,7 +202,7 @@ void Libxc::callLibEval(const Eigen::MatrixXd &inp, Eigen::MatrixXd &out, int nP
                     }
                     xc_gga_exc_vxc(libxc_objects[i], nPts, rho.data(), sigma.data(), exc.data(), vxc.data(), sxc.data());
 
-                    for (size_t j = 0; j < nPts; ++j) {
+                    for (int j = 0; j < nPts; ++j) {
                         // clang-format off
                         //    xcfun calculates energy density per volume while libxc calculates
                         //    energy density per electron, so we multiply by the density here
@@ -226,10 +226,10 @@ void Libxc::callLibEval(const Eigen::MatrixXd &inp, Eigen::MatrixXd &out, int nP
                     vxc = Eigen::MatrixXd::Zero(1, nPts);
                     sxc = Eigen::MatrixXd::Zero(1, nPts);
                     sigma = Eigen::MatrixXd::Zero(1, nPts);
-                    for (size_t j = 0; j < nPts; j++) { sigma(j) = inp(1, j) * inp(1, j) + inp(2, j) * inp(2, j) + inp(3, j) * inp(3, j); }
+                    for (int j = 0; j < nPts; j++) { sigma(j) = inp(1, j) * inp(1, j) + inp(2, j) * inp(2, j) + inp(3, j) * inp(3, j); }
                     xc_gga_exc_vxc(libxc_objects[i], nPts, rho.data(), sigma.data(), exc.data(), vxc.data(), sxc.data());
 
-                    for (size_t j = 0; j < nPts; ++j) {
+                    for (int j = 0; j < nPts; ++j) {
                         //    xcfun calculates energy density per volume while libxc calculates
                         //    energy density per electron, so we multiply by the density here
                         out(0, j) += exc(0, j) * libxc_coefs[i] * inp(0, j);

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -194,7 +194,7 @@ void GroundStateSolver::printParameters(const std::string &calculation) const {
     mrcpp::print::separator(0, '~');
     print_utils::text(0, "Calculation        ", calculation);
     print_utils::text(0, "Method             ", this->methodName);
-    print_utils::text(0, "XC library         ", (this->libxc) ? "LibXC" : "XCFun");
+    print_utils::text(0, "XC library         ", this->xclib);
     print_utils::text(0, "Relativity         ", this->relativityName);
     print_utils::text(0, "Environment        ", this->environmentName);
     print_utils::text(0, "External fields    ", this->externalFieldName);

--- a/src/scf_solver/SCFSolver.h
+++ b/src/scf_solver/SCFSolver.h
@@ -57,7 +57,7 @@ public:
     void setHelmholtzPrec(double prec) { this->helmPrec = prec; }
     void setMaxIterations(int iter) { this->maxIter = iter; }
     void setMethodName(const std::string &name) { this->methodName = name; }
-    void setLibxc(bool libxc_) { this->libxc = libxc_; }
+    void setXCLibName(const std::string &name) { this->xclib = name; }
     void setRelativityName(const std::string &name) { this->relativityName = name; }
     void setEnvironmentName(const std::string &name) { this->environmentName = name; }
     void setExternalFieldName(const std::string &name) { this->externalFieldName = name; }
@@ -74,7 +74,7 @@ protected:
     std::string relativityName{"None"};    ///< Name of ZORA method
     std::string environmentName{"None"};   ///< Name for external environment
     std::string externalFieldName{"None"}; ///< Name for external fields
-    bool libxc;                            ///< Type of XC Library
+    std::string xclib;                     ///< Type of XC Library
 
     std::vector<double> error;    ///< Convergence orbital error
     std::vector<double> property; ///< Convergence property error

--- a/src/surface_forces/SurfaceForce.cpp
+++ b/src/surface_forces/SurfaceForce.cpp
@@ -277,8 +277,7 @@ Eigen::MatrixXd surface_forces(mrchem::Molecule &mol, mrchem::OrbitalVector &Phi
     auto xc_order = order + 1;
     auto funcVectorShared = std::make_shared<OrbitalVector>(Phi);
 
-    mrdft::Factory xc_factory(*MRA);
-    xc_factory.setSpin(xc_spin);
+    mrdft::Factory xc_factory(*MRA, xc_spin, "xcfun");
     xc_factory.setOrder(xc_order);
     xc_factory.setDensityCutoff(xc_cutoff);
     for (const auto &f : xc_funcs) {
@@ -288,8 +287,7 @@ Eigen::MatrixXd surface_forces(mrchem::Molecule &mol, mrchem::OrbitalVector &Phi
     }
     std::unique_ptr<mrdft::MRDFT> mrdft_p = xc_factory.build();
 
-    mrdft::Factory xc_factory2(*MRA);
-    xc_factory2.setSpin(xc_spin);
+    mrdft::Factory xc_factory2(*MRA, xc_spin, "xcfun");
     xc_factory2.setOrder(xc_order);
     xc_factory2.setDensityCutoff(xc_cutoff);
     for (const auto &f : xc_funcs) {

--- a/src/surface_forces/SurfaceForce.cpp
+++ b/src/surface_forces/SurfaceForce.cpp
@@ -274,10 +274,11 @@ Eigen::MatrixXd surface_forces(mrchem::Molecule &mol, mrchem::OrbitalVector &Phi
     bool xc_spin = json_xcfunc["spin"];
     auto xc_cutoff = json_xcfunc["cutoff"];
     auto xc_funcs = json_xcfunc["functionals"];
+    auto xc_lib = json_fock["xc_library"];
     auto xc_order = order + 1;
     auto funcVectorShared = std::make_shared<OrbitalVector>(Phi);
 
-    mrdft::Factory xc_factory(*MRA, xc_spin, "xcfun");
+    mrdft::Factory xc_factory(*MRA, xc_spin, xc_lib);
     xc_factory.setOrder(xc_order);
     xc_factory.setDensityCutoff(xc_cutoff);
     for (const auto &f : xc_funcs) {
@@ -287,7 +288,7 @@ Eigen::MatrixXd surface_forces(mrchem::Molecule &mol, mrchem::OrbitalVector &Phi
     }
     std::unique_ptr<mrdft::MRDFT> mrdft_p = xc_factory.build();
 
-    mrdft::Factory xc_factory2(*MRA, xc_spin, "xcfun");
+    mrdft::Factory xc_factory2(*MRA, xc_spin, xc_lib);
     xc_factory2.setOrder(xc_order);
     xc_factory2.setDensityCutoff(xc_cutoff);
     for (const auto &f : xc_funcs) {

--- a/tests/qmoperators/xc_hessian_lda.cpp
+++ b/tests/qmoperators/xc_hessian_lda.cpp
@@ -53,7 +53,7 @@ TEST_CASE("XCHessianLDA", "[xc_hessian_lda]") {
     auto Phi_p = std::make_shared<OrbitalVector>();
     auto X_p = std::make_shared<OrbitalVector>();
 
-    mrdft::Factory xc_factory(*MRA);
+    mrdft::Factory xc_factory(*MRA, false, "xcfun");
     xc_factory.setOrder(MRDFT::Hessian);
     xc_factory.setUseGamma(true);
     xc_factory.setFunctional("LDA", 1.0);

--- a/tests/qmoperators/xc_hessian_pbe.cpp
+++ b/tests/qmoperators/xc_hessian_pbe.cpp
@@ -53,7 +53,7 @@ TEST_CASE("XCHessianPBE", "[xc_hessian_pbe]") {
     auto Phi_p = std::make_shared<OrbitalVector>();
     auto X_p = std::make_shared<OrbitalVector>();
 
-    mrdft::Factory xc_factory(*MRA);
+    mrdft::Factory xc_factory(*MRA, false, "xcfun");
     xc_factory.setOrder(MRDFT::Hessian);
     xc_factory.setFunctional("PBE", 1.0);
     xc_factory.setDensityCutoff(1.0e-10);

--- a/tests/qmoperators/xc_operator_blyp.cpp
+++ b/tests/qmoperators/xc_operator_blyp.cpp
@@ -54,7 +54,7 @@ TEST_CASE("XCOperatorBLYP", "[xc_operator_blyp]") {
 
     auto Phi_p = std::make_shared<OrbitalVector>();
 
-    mrdft::Factory xc_factory(*MRA);
+    mrdft::Factory xc_factory(*MRA, false, "xcfun");
     xc_factory.setOrder(MRDFT::Gradient);
     xc_factory.setFunctional("BLYP", 1.0);
     xc_factory.setDensityCutoff(1.0e-10);

--- a/tests/qmoperators/xc_operator_lda.cpp
+++ b/tests/qmoperators/xc_operator_lda.cpp
@@ -53,7 +53,7 @@ TEST_CASE("[XCOperatorLDA]", "[xc_operator_lda]") {
 
     auto Phi_p = std::make_shared<OrbitalVector>();
 
-    mrdft::Factory xc_factory(*MRA);
+    mrdft::Factory xc_factory(*MRA, false, "xcfun");
     xc_factory.setOrder(MRDFT::Gradient);
     xc_factory.setFunctional("LDA", 1.0);
     xc_factory.setDensityCutoff(1.0e-10);


### PR DESCRIPTION
## Summary by Sourcery

Replace global boolean-based XC library selection with explicit library name handling across the MRDFT factory and SCF flow, and address minor interface and warning fixes.

New Features:
- Allow choosing XC backend via a string library name (e.g. "xcfun" or "libxc") in Factory, SCF solver, and JSON inputs.
- Propagate selected XC library into initial guess routines (SAD and NAO) and surface force calculations.

Bug Fixes:
- Fix JSON parsing of xc_library fields to treat them as simple strings and avoid array/object handling issues.
- Correct type warnings in Libxc loops by using int indices for iteration.
- Ensure clear() overrides in LDA/GGA and spin variants are explicitly marked as overrides to match the base class interface.

Enhancements:
- Simplify XC backend management by removing the static XClib::libxc flag and associated rebuild/setters in Factory.
- Update SCF parameter printing and logs to report the actual XC library name instead of a boolean-derived label.
- Clean up Python helper generation of xc_library fields to produce a consistent schema and avoid redundant wrapping.

Tests:
- Update XC-related unit tests to construct MRDFT Factory with the new constructor signature and explicit xc_library selection.